### PR TITLE
Update Physique quantique et statistique - Nicolas Englebert.tex

### DIFF
--- a/IRCI2/Physique quantique et statistique/Physique quantique et statistique - Nicolas Englebert.tex
+++ b/IRCI2/Physique quantique et statistique/Physique quantique et statistique - Nicolas Englebert.tex
@@ -1753,7 +1753,7 @@ seule variable, les fonctions propres de $\tilde{H}$ sont de la forme :
 	\tilde{\psi}(\vec{r_1},\vec{r_2}) = \psi_{n_1l_1m_1}(\vec{r_1})\psi_{n_2l_2m_2}(
 	\vec{r_2})
 \end{equation}
-En évaluant sont produit avec $\tilde{H}$ et en appliquant la définition faisant
+En évaluant son produit avec $\tilde{H}$ et en appliquant la définition faisant
 apparaître les valeurs propres : 
 \begin{equation}
 	\begin{array}{ll}


### PR DESCRIPTION
Correction orthographique: "sont produit" par "son produit", dans Chapitre 9: Les atomes